### PR TITLE
Add missing sqlite plugin

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -87,6 +87,7 @@
   <plugin name="cordova-plugin-whitelist" spec="~1.3.0"/>
   <plugin name="cordova-plugin-splashscreen" spec="~4.0.0"/>
   <plugin name="cordova-plugin-statusbar" spec="~2.2.0"/>
+  <plugin name="cordova-sqlite-storage" spec="~2.0.1"/>
   <plugin name="ionic-plugin-keyboard" spec="~2.2.1"/>
   <icon src="resources/android/icon/drawable-xhdpi-icon.png"/>
 </widget>


### PR DESCRIPTION
Using this plugin makes sure the SQLite DB is saved persistently to a file on the device.